### PR TITLE
Kill node before running npm start

### DIFF
--- a/scripts/start_server
+++ b/scripts/start_server
@@ -1,3 +1,4 @@
 #!/bin/bash
+killall -9 node
 cd home/ec2-user/app
 npm start


### PR DESCRIPTION
Deployment is failing when node server is already running because port is already in use.